### PR TITLE
Change fps for stability

### DIFF
--- a/main.py
+++ b/main.py
@@ -148,7 +148,7 @@ with dai.Device(pipeline) as device:
         inIsp = qIsp.get()
         inDet = qDet.get()
 
-        if inIsp is not None:
+        if inRgb is not None:
             frame = inRgb.getCvFrame()
             cv2.putText(frame, "NN fps: {:.2f}".format(counter / (time.monotonic() - startTime)),
                         (2, frame.shape[0] - 4), cv2.FONT_HERSHEY_TRIPLEX, 0.4, color2)

--- a/main.py
+++ b/main.py
@@ -74,7 +74,7 @@ camRgb.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
 camRgb.setInterleaved(False)
 camRgb.setColorOrder(dai.ColorCameraProperties.ColorOrder.BGR)
 camRgb.setPreviewSize(1920, 1080)
-camRgb.setFps(30)
+camRgb.setFps(10)
 
 xoutIsp = pipeline.create(dai.node.XLinkOut)
 xoutIsp.setStreamName("isp")


### PR DESCRIPTION
yolov7などモデルによっては10FPSを超えるとOAK-Dが落ちるので、安定しているFPSに落としておきます。